### PR TITLE
Fix setTheme parameter name in ThemeProvider

### DIFF
--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -51,8 +51,6 @@ export function ThemeProvider({
 
   const value = {
     theme,
-    setTheme: (theme: Theme) => {
-      localStorage.setItem(storageKey, theme)
     setTheme: (newTheme: Theme) => {
       localStorage.setItem(storageKey, newTheme)
       setTheme(newTheme)

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -28,7 +28,7 @@ export function ThemeProvider({
   storageKey = "xchat-theme",
   ...props
 }: ThemeProviderProps) {
-  const [theme, setTheme] = React.useState<Theme>(
+  const [theme, setThemeState] = React.useState<Theme>(
     () => (typeof window !== "undefined" && (localStorage.getItem(storageKey) as Theme)) || defaultTheme
   )
 
@@ -53,7 +53,7 @@ export function ThemeProvider({
     theme,
     setTheme: (newTheme: Theme) => {
       localStorage.setItem(storageKey, newTheme)
-      setTheme(newTheme)
+      setThemeState(newTheme)
     },
   }
 


### PR DESCRIPTION
Renamed the parameter in setTheme from 'theme' to 'newTheme' for clarity and consistency. This helps prevent confusion between the current theme and the new value being set.